### PR TITLE
Add support for string parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ end
 
 The following job attributes are supported:
 
-* `description`
 * `project_type` -- doesn't normally need to be specified.  If any `axes` are added to the
   job, then `project_type` is automatically inferred to be `matrix`
 * `description`
@@ -107,6 +106,7 @@ The following job attributes are supported:
 The following sections and components are supported:
 
 * `axes`: (`label_expression`, `slave`)
+* `parameters`: (`string`)
 * `properties`: (`throttle`)
 * `scm`: (`git`, `store`)
 * `triggers`: (`pollscm`, `pollurl`, `reverse`)

--- a/acceptance/fixtures/endToEnd/endToEnd.job
+++ b/acceptance/fixtures/endToEnd/endToEnd.job
@@ -8,6 +8,8 @@ job "endToEnd" do |j|
 
   j.axes << slave(:arch, %w{i386 amd64})
 
+  j.parameters << string(name: "STRING_PARAM", default: "DEFAULT VALUE", description: "DESCRIPTION")
+
   j.properties << throttle(max_per_node: 2,
                            max_total: 4,
                            option: "category",
@@ -56,6 +58,4 @@ job "endToEnd" do |j|
   j.publishers << xunit do |types|
     types << unittest(pattern: "PATTERN", deleteoutput: false)
   end
-
-  j.parameters << string(name: "some-param", default: "def_val", description: "Some string parameter.")
 end

--- a/acceptance/fixtures/endToEnd/endToEnd.job
+++ b/acceptance/fixtures/endToEnd/endToEnd.job
@@ -56,4 +56,6 @@ job "endToEnd" do |j|
   j.publishers << xunit do |types|
     types << unittest(pattern: "PATTERN", deleteoutput: false)
   end
+
+  j.parameters << string(name: "some-param", default: "def_val", description: "Some string parameter.")
 end

--- a/acceptance/fixtures/endToEnd/expected.yml
+++ b/acceptance/fixtures/endToEnd/expected.yml
@@ -15,6 +15,11 @@
           values:
             - i386
             - amd64
+    parameters:
+      - string:
+          name: STRING_PARAM
+          default: "DEFAULT VALUE"
+          description: DESCRIPTION
     properties:
       - throttle:
           max-per-node: 2
@@ -105,8 +110,3 @@
             - unittest:
                 pattern: PATTERN
                 deleteoutput: false
-    parameters:
-      - string:
-          name: some-param
-          default: def_val
-          description: "Some string parameter."

--- a/acceptance/fixtures/endToEnd/expected.yml
+++ b/acceptance/fixtures/endToEnd/expected.yml
@@ -105,3 +105,8 @@
             - unittest:
                 pattern: PATTERN
                 deleteoutput: false
+    parameters:
+      - string:
+          name: some-param
+          default: def_val
+          description: "Some string parameter."

--- a/jujube.gemspec
+++ b/jujube.gemspec
@@ -1,29 +1,29 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'jujube/version'
+require "jujube/version"
 
 Gem::Specification.new do |spec|
-  spec.name = 'jujube'
+  spec.name = "jujube"
   spec.version = Jujube::VERSION
-  spec.authors = ['Randy Coulman']
-  spec.email = ['rcoulman@gmail.com']
+  spec.authors = ["Randy Coulman"]
+  spec.email = ["rcoulman@gmail.com"]
   spec.description = <<EOF
 Jujube provides a Ruby front-end for specifying Jenkins jobs.  It generates YAML files that
 are then used as input for jenkins-job-builder.
 EOF
   spec.summary = %q{Ruby front-end for jenkins-job-builder}
-  spec.homepage = 'https://github.com/randycoulman/jujube'
-  spec.license = 'MIT'
+  spec.homepage = "https://github.com/randycoulman/jujube"
+  spec.license = "MIT"
 
   spec.files = `git ls-files`.split($/)
   spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files = spec.files.grep(%r{^(test|spec|features|acceptance)/})
-  spec.require_paths = ['lib']
+  spec.require_paths = ["lib"]
 
-  spec.add_development_dependency 'bundler', '~> 1.3'
-  spec.add_development_dependency 'rake', '~> 10.1'
-  spec.add_development_dependency 'minitest', '~> 5.3'
-  spec.add_development_dependency 'flexmock', '~> 2.0'
-  spec.add_development_dependency 'yard', '~>0.8.7'
+  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "rake", "~> 10.1"
+  spec.add_development_dependency "minitest", "~> 5.3"
+  spec.add_development_dependency "flexmock", "~> 2.0"
+  spec.add_development_dependency "yard", "~>0.8.7"
 end

--- a/jujube.gemspec
+++ b/jujube.gemspec
@@ -4,26 +4,26 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'jujube/version'
 
 Gem::Specification.new do |spec|
-  spec.name = "jujube"
+  spec.name = 'jujube'
   spec.version = Jujube::VERSION
-  spec.authors = ["Randy Coulman"]
-  spec.email = ["rcoulman@gmail.com"]
+  spec.authors = ['Randy Coulman']
+  spec.email = ['rcoulman@gmail.com']
   spec.description = <<EOF
 Jujube provides a Ruby front-end for specifying Jenkins jobs.  It generates YAML files that
 are then used as input for jenkins-job-builder.
 EOF
   spec.summary = %q{Ruby front-end for jenkins-job-builder}
-  spec.homepage = "https://github.com/randycoulman/jujube"
-  spec.license = "MIT"
+  spec.homepage = 'https://github.com/randycoulman/jujube'
+  spec.license = 'MIT'
 
   spec.files = `git ls-files`.split($/)
   spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files = spec.files.grep(%r{^(test|spec|features|acceptance)/})
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rake", "~> 10.1"
-  spec.add_development_dependency "minitest", "~> 5.3"
-  spec.add_development_dependency "flexmock", "~> 2.0"
-  spec.add_development_dependency "yard", "~>0.8.7"
+  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'rake', '~> 10.1'
+  spec.add_development_dependency 'minitest', '~> 5.3'
+  spec.add_development_dependency 'flexmock', '~> 2.0'
+  spec.add_development_dependency 'yard', '~>0.8.7'
 end

--- a/lib/jujube/components/parameters.rb
+++ b/lib/jujube/components/parameters.rb
@@ -3,6 +3,16 @@ module Jujube
 
     # Helper methods for creating job parameter components.
     module Parameters
+      extend Macros
+
+      # @!method string(options = {})
+      # Specify a `string` parameter for a job.
+      #
+      # See {http://docs.openstack.org/infra/jenkins-job-builder/parameters.html#parameters.string}.
+      #
+      # @param options [Hash] The configuration options for the component.
+      # @return [Hash] The specification for the component.
+      standard_component :string
 
       # @!group Matrix Axes
 

--- a/lib/jujube/components/parameters.rb
+++ b/lib/jujube/components/parameters.rb
@@ -5,15 +5,6 @@ module Jujube
     module Parameters
       extend Macros
 
-      # @!method string(options = {})
-      # Specify a `string` parameter for a job.
-      #
-      # See {http://docs.openstack.org/infra/jenkins-job-builder/parameters.html#parameters.string}.
-      #
-      # @param options [Hash] The configuration options for the component.
-      # @return [Hash] The specification for the component.
-      standard_component :string
-
       # @!group Matrix Axes
 
       # Specify a `label-expression` axis for a matrix job.
@@ -37,6 +28,15 @@ module Jujube
       def slave(name, values)
         axis(name, values, :slave)
       end
+
+      # @!method string(options = {})
+      # Specify a `string` parameter for a job.
+      #
+      # See {http://docs.openstack.org/infra/jenkins-job-builder/parameters.html#parameters.string}.
+      #
+      # @param options [Hash] The configuration options for the component.
+      # @return [Hash] The specification for the component.
+      standard_component :string
 
       private
 

--- a/lib/jujube/job.rb
+++ b/lib/jujube/job.rb
@@ -104,6 +104,17 @@ module Jujube
     #   @return [Array]
     section :axes
 
+    # @!method parameters
+    #   The parameters for the job.
+    #
+    #   Add parameters in the job's configuration block using helper methods defined in
+    #   {Components::Parameters}.
+    #
+    #   See {http://docs.openstack.org/infra/jenkins-job-builder/parameters.html}.
+    #
+    #   @return [Array]
+    section :parameters
+
     # @!method properties
     #   The Properties for the job.
     #
@@ -180,17 +191,6 @@ module Jujube
     #
     #   @return [Array]
     section :notifications
-
-    # @!method parameters
-    #   The parameters for the job.
-    #
-    #   Add parameters in the job's configuration block using helper methods defined in
-    #   {Components::Parameters}.
-    #
-    #   See {http://docs.openstack.org/infra/jenkins-job-builder/parameters.html}.
-    #
-    #   @return [Array]
-    section :parameters
 
     # @!endgroup
 

--- a/lib/jujube/job.rb
+++ b/lib/jujube/job.rb
@@ -181,6 +181,17 @@ module Jujube
     #   @return [Array]
     section :notifications
 
+    # @!method parameters
+    #   The parameters for the job.
+    #
+    #   Add parameters in the job's configuration block using helper methods defined in
+    #   {Components::Parameters}.
+    #
+    #   See {http://docs.openstack.org/infra/jenkins-job-builder/parameters.html}.
+    #
+    #   @return [Array]
+    section :parameters
+
     # @!endgroup
 
     # Generate a YAML representation of the `Job`.

--- a/lib/jujube/version.rb
+++ b/lib/jujube/version.rb
@@ -1,3 +1,3 @@
 module Jujube
-  VERSION = "0.12.0"
+  VERSION = "0.11.0"
 end

--- a/lib/jujube/version.rb
+++ b/lib/jujube/version.rb
@@ -1,3 +1,3 @@
 module Jujube
-  VERSION = "0.11.0"
+  VERSION = "0.12.0"
 end


### PR DESCRIPTION
Add support for the `parameters` section, and `string` parameters within that.

This PR makes the necessary changes and adjustments to #2.

Closes #2.