### PR TITLE
Update dependencies

### DIFF
--- a/acceptance/jujube/acceptance_test.rb
+++ b/acceptance/jujube/acceptance_test.rb
@@ -26,11 +26,11 @@ class AcceptanceTest < Minitest::Test
   end
 
   def assert_file_exists(filename)
-    assert(File.exists?(filename), "File #{filename} does not exist")
+    assert(File.exist?(filename), "File #{filename} does not exist")
   end
 
   def assert_directory_exists(filename)
-    assert(Dir.exists?(filename), "Directory #{filename} does not exist")
+    assert(Dir.exist?(filename), "Directory #{filename} does not exist")
   end
 
   def fixture_root

--- a/jujube.gemspec
+++ b/jujube.gemspec
@@ -22,7 +22,7 @@ EOF
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rake", "~> 10.1"
+  spec.add_development_dependency "rake", ">= 10.1", "< 12"
   spec.add_development_dependency "minitest", "~> 5.3"
   spec.add_development_dependency "flexmock", "~> 2.0"
   spec.add_development_dependency "yard", "~>0.8.7"

--- a/lib/jujube/components/triggers.rb
+++ b/lib/jujube/components/triggers.rb
@@ -5,6 +5,7 @@ module Jujube
     module Triggers
       extend Macros
 
+      # @!method pollscm(options = {})
       # Specify a `pollscm` trigger for a job.
       #
       # This trigger requires jenkins-job-builder 1.3.0 or later.

--- a/lib/jujube/job.rb
+++ b/lib/jujube/job.rb
@@ -205,6 +205,8 @@ module Jujube
       {'job' => config}
     end
 
+    @registry = nil
+
     # Keep track of all `Job`s defined during the execution of the passed block.
     #
     # This is used during job loading so that no extra syntax is required in the job


### PR DESCRIPTION
* Allow Rake 10.x or 11.x
* Eliminate deprecation warnings
* Eliminate warning about unused variable
* Eliminate YARD warning about unrecognized `@param`

Note that there is still one deprecation warning when using Rake 11.  It comes from YARD and has been fixed upstream (https://github.com/lsegal/yard/pull/946), but not yet released.