### PR TITLE
Extract matrix axes to their own file

### DIFF
--- a/lib/jujube/components.rb
+++ b/lib/jujube/components.rb
@@ -1,5 +1,6 @@
 require_relative "components/macros"
 require_relative "components/helpers"
+require_relative "components/axes"
 require_relative "components/parameters"
 require_relative "components/properties"
 require_relative "components/scm"
@@ -13,6 +14,7 @@ module Jujube
   # Helper methods for creating jenkins-job-builder components.
   module Components
     include Helpers
+    include Axes
     include Parameters
     include Properties
     include Scm

--- a/lib/jujube/components/axes.rb
+++ b/lib/jujube/components/axes.rb
@@ -1,0 +1,46 @@
+module Jujube
+  module Components
+
+    # Helper methods for creating matrix axes components.
+    module Axes
+      extend Macros
+
+      # Specify a `label-expression` axis for a matrix job.
+      #
+      # See {http://docs.openstack.org/infra/jenkins-job-builder/project_matrix.html}.
+      #
+      # @param name [Symbol, String] The name of the axis.
+      # @param values [Array<String>] The values of the axis.
+      # @return [Hash] The specification for the axis.
+      def label_expression(name, values)
+        axis(name, values, :label_expression)
+      end
+
+      # Specify a `slave` axis for a matrix job.
+      #
+      # See {http://docs.openstack.org/infra/jenkins-job-builder/project_matrix.html}.
+      #
+      # @param name [Symbol, String] The name of the axis.
+      # @param values [Array<String>] The values of the axis.
+      # @return [Hash] The specification for the axis.
+      def slave(name, values)
+        axis(name, values, :slave)
+      end
+
+      private
+
+      # Specify an axis for a matrix job.
+      #
+      # See {http://docs.openstack.org/infra/jenkins-job-builder/project_matrix.html}.
+      #
+      # @param name [Symbol, String] The name of the axis.
+      # @param values [Array<String>] The values of the axis.
+      # @param type [Symbol, String] The axis type.
+      # @return [Hash] The specification for the axis.
+      def axis(name, values, type)
+        options = {type: canonicalize(type), name: canonicalize(name), values: values}
+        to_config("axis", options)
+      end
+    end
+  end
+end

--- a/lib/jujube/components/parameters.rb
+++ b/lib/jujube/components/parameters.rb
@@ -5,30 +5,6 @@ module Jujube
     module Parameters
       extend Macros
 
-      # @!group Matrix Axes
-
-      # Specify a `label-expression` axis for a matrix job.
-      #
-      # See {http://docs.openstack.org/infra/jenkins-job-builder/project_matrix.html}.
-      #
-      # @param name [Symbol, String] The name of the axis.
-      # @param values [Array<String>] The values of the axis.
-      # @return [Hash] The specification for the axis.
-      def label_expression(name, values)
-        axis(name, values, :label_expression)
-      end
-
-      # Specify a `slave` axis for a matrix job.
-      #
-      # See {http://docs.openstack.org/infra/jenkins-job-builder/project_matrix.html}.
-      #
-      # @param name [Symbol, String] The name of the axis.
-      # @param values [Array<String>] The values of the axis.
-      # @return [Hash] The specification for the axis.
-      def slave(name, values)
-        axis(name, values, :slave)
-      end
-
       # @!method string(options = {})
       # Specify a `string` parameter for a job.
       #
@@ -37,24 +13,6 @@ module Jujube
       # @param options [Hash] The configuration options for the component.
       # @return [Hash] The specification for the component.
       standard_component :string
-
-      private
-
-      # Specify an axis for a matrix job.
-      #
-      # See {http://docs.openstack.org/infra/jenkins-job-builder/project_matrix.html}.
-      #
-      # @param name [Symbol, String] The name of the axis.
-      # @param values [Array<String>] The values of the axis.
-      # @param type [Symbol, String] The axis type.
-      # @return [Hash] The specification for the axis.
-      def axis(name, values, type)
-        options = {type: canonicalize(type), name: canonicalize(name), values: values}
-        to_config("axis", options)
-      end
-
-      # @!endgroup
-
     end
   end
 end


### PR DESCRIPTION
They have a separate section in `job.rb`, so they deserve their own
file rather than being grouped in with parameters.