### PR TITLE
Support the trigger-parameterized-builds publisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The following sections and components are supported:
 * `wrappers`: (`timeout`, `timestamps`)
 * `builders`: (`shell`)
 * `publishers`: (`archive`, `cppcheck`, `email_ext`, `fitnesse`, `ircbot`, `junit`, 
-  `trigger`, `unittest`, `xunit`)
+  `trigger`, `trigger_parameterized_builds`, `unittest`, `xunit`)
 * `notifications`: None defined yet
 
 See [the end-to-end example job](examples/fixtures/endToEnd/endToEnd.job) for example

--- a/acceptance/fixtures/endToEnd/endToEnd.job
+++ b/acceptance/fixtures/endToEnd/endToEnd.job
@@ -15,11 +15,11 @@ job "endToEnd" do |j|
                                     regex: "REGEX",
                                     msg: "MESSAGE")
 
+  j.properties << priority_sorter(priority: 150)
   j.properties << throttle(max_per_node: 2,
                            max_total: 4,
                            option: "category",
                            categories: %w{CAT1 CAT2})
-  j.properties << priority_sorter(priority: 150)
 
   j.scm << git(url: "URL", branches: %w{master dev}, wipe_workspace: false)
   j.scm << store(script: "SCRIPT",
@@ -60,6 +60,29 @@ job "endToEnd" do |j|
   j.publishers << ircbot(notify_start: true)
   j.publishers << junit(results: "RESULTS", keep_long_stdio: false)
   j.publishers << trigger(project: "PROJECT")
+  j.publishers << trigger_parameterized_builds do |builds|
+    builds << build(project: %w[PROJECT1 PROJECT2],
+                    predefined_parameters: { param1: "VALUE1", param2: "VALUE2" },
+                    current_parameters: true,
+                    node_parameters: false,
+                    svn_revision: true,
+                    include_upstream: false,
+                    git_revision: { combine_queued_commits: true },
+                    boolean_parameters: { bool1: true, bool2: false },
+                    condition: "FAILED_OR_BETTER",
+                    property_file: "FILE.properties",
+                    fail_on_missing: true,
+                    use_matrix_child_files: false,
+                    only_exact_matrix_child_runs: true,
+                    file_encoding: "UTF-8",
+                    trigger_with_no_params: false,
+                    restrict_matrix_project: 'label=="x86"',
+                    node_label_name: "LABEL_NAME",
+                    node_label: "LABEL")
+    builds << build(project: "SINGLE_PROJECT",
+                    predefined_parameters: { param: "VALUE" },
+                    git_revision: true)
+  end
   j.publishers << xunit do |types|
     types << unittest(pattern: "PATTERN", deleteoutput: false)
   end

--- a/acceptance/fixtures/endToEnd/expected.yml
+++ b/acceptance/fixtures/endToEnd/expected.yml
@@ -27,6 +27,8 @@
           regex: REGEX
           msg: MESSAGE
     properties:
+      - priority-sorter:
+          priority: 150
       - throttle:
           max-per-node: 2
           max-total: 4
@@ -34,8 +36,6 @@
           categories:
             - CAT1
             - CAT2
-      - priority-sorter:
-          priority: 150
     scm:
       - git:
           url: URL
@@ -111,6 +111,35 @@
           keep-long-stdio: false
       - trigger:
           project: PROJECT
+      - trigger-parameterized-builds:
+        - project:
+            - PROJECT1
+            - PROJECT2
+          predefined-parameters: |
+            param1=VALUE1
+            param2=VALUE2
+          current-parameters: true
+          node-parameters: false
+          svn-revision: true
+          include-upstream: false
+          git-revision:
+            combine-queued-commits: true
+          boolean-parameters:
+              bool1: true
+              bool2: false
+          condition: FAILED_OR_BETTER
+          property-file: FILE.properties
+          fail-on-missing: true
+          use-matrix-child-files: false
+          only-exact-matrix-child-runs: true
+          file-encoding: UTF-8
+          trigger-with-no-params: false
+          restrict-matrix-project: label=="x86"
+          node-label-name: LABEL_NAME
+          node-label: LABEL
+        - project: SINGLE_PROJECT
+          predefined-parameters: param=VALUE
+          git-revision: true
       - xunit:
           types:
             - unittest:

--- a/test/components/publishers_test.rb
+++ b/test/components/publishers_test.rb
@@ -42,6 +42,66 @@ class PublishersTest < Minitest::Test
     assert_equal(expected, trigger(project: "PROJECT"))
   end
 
+  def test_trigger_parameterized_builds
+    expected = {"trigger-parameterized-builds" => [
+        {"project" => ["PROJECT1", "PROJECT2"], "condition" => "UNSTABLE"}
+    ]}
+    actual = trigger_parameterized_builds do |builds|
+      builds << build(project: %w[PROJECT1 PROJECT2], condition: "UNSTABLE")
+    end
+    assert_equal(expected, actual)
+  end
+
+  def test_trigger_parameterized_builds_formats_single_predefined_parameter
+    expected = {"trigger-parameterized-builds" => [
+        {"predefined-parameters" => "param=value"}
+    ]}
+    actual = trigger_parameterized_builds do |builds|
+      builds << build(predefined_parameters: {param: 'value'})
+    end
+    assert_equal(expected, actual)
+  end
+
+  def test_trigger_parameterized_builds_formats_multiiple_predefined_parameters
+    expected = {"trigger-parameterized-builds" => [
+        {"predefined-parameters" => "param1=value1\nparam2=value2\n"}
+    ]}
+    actual = trigger_parameterized_builds do |builds|
+      builds << build(predefined_parameters: {param1: 'value1', param2: 'value2'})
+    end
+    assert_equal(expected, actual)
+  end
+
+  def test_trigger_parameterized_builds_formats_boolean_parameters
+    expected = {"trigger-parameterized-builds" => [
+        {"boolean-parameters" => {"param_1" => true, "param_2" => false}}
+    ]}
+    actual = trigger_parameterized_builds do |builds|
+      builds << build(boolean_parameters: {param_1: true, param_2: false})
+    end
+    assert_equal(expected, actual)
+  end
+
+  def test_trigger_parameterized_builds_formats_git_revision_as_boolean
+    expected = {"trigger-parameterized-builds" => [
+        {"git-revision" => true}
+    ]}
+    actual = trigger_parameterized_builds do |builds|
+      builds << build(git_revision: true)
+    end
+    assert_equal(expected, actual)
+  end
+
+  def test_trigger_parameterized_builds_formats_git_revision_as_nested_hash
+    expected = {"trigger-parameterized-builds" => [
+        {"git-revision" => {"combine-queued-commits" => true}}
+    ]}
+    actual = trigger_parameterized_builds do |builds|
+      builds << build(git_revision: {combine_queued_commits: true})
+    end
+    assert_equal(expected, actual)
+  end
+
   def test_xunit
     expected = {"xunit" =>
                     {"types" =>


### PR DESCRIPTION
This publisher takes a lot of options, some of which need special handling.