### PR TITLE
Add a builder for `copyartifact`

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ The following sections and components are supported:
 * `scm`: (`git`, `store`)
 * `triggers`: (`pollscm`, `pollurl`, `reverse`)
 * `wrappers`: (`timeout`, `timestamps`)
-* `builders`: (`shell`)
-* `publishers`: (`archive`, `cppcheck`, `email_ext`, `fitnesse`, `ircbot`, `junit`, 
+* `builders`: (`copyartifact`, `shell`)
+* `publishers`: (`archive`, `cppcheck`, `email_ext`, `fitnesse`, `ircbot`, `junit`,
   `trigger`, `trigger_parameterized_builds`, `unittest`, `xunit`)
 * `notifications`: None defined yet
 

--- a/acceptance/fixtures/endToEnd/endToEnd.job
+++ b/acceptance/fixtures/endToEnd/endToEnd.job
@@ -51,6 +51,7 @@ job "endToEnd" do |j|
   j.wrappers << timeout(type: 'elastic', elastic_percentage: 150, elastic_default_timeout: 5, fail: true)
   j.wrappers << timestamps
 
+  j.builders << copyartifact(project: "PROJECT", filter: "FILTER", target: "TARGET", flatten: true)
   j.builders << shell("COMMAND")
 
   j.publishers << archive(artifacts: "ARTIFACTS", latest_only: true, allow_empty: true)

--- a/acceptance/fixtures/endToEnd/expected.yml
+++ b/acceptance/fixtures/endToEnd/expected.yml
@@ -90,6 +90,11 @@
           fail: true
       - timestamps
     builders:
+      - copyartifact:
+          project: PROJECT
+          filter: FILTER
+          target: TARGET
+          flatten: true
       - shell: COMMAND
     publishers:
       - archive:

--- a/lib/jujube/components/builders.rb
+++ b/lib/jujube/components/builders.rb
@@ -5,6 +5,15 @@ module Jujube
     module Builders
       extend Macros
 
+      # @!method copyartifact(options = {})
+      # Specify a `copyartifact` builder for a job. Requires the `copyartifact` plugin.
+      #
+      # See {https://docs.openstack.org/infra/jenkins-job-builder/builders.html#builders.copyartifact}.
+      #
+      # @param options [Hash] The configuration options for the component.
+      # @return [Hash] The specification for the component.
+      standard_component :copyartifact
+
       # Specify a `shell` builder for a job.
       #
       # See {http://docs.openstack.org/infra/jenkins-job-builder/builders.html#builders.shell}.
@@ -14,15 +23,6 @@ module Jujube
       def shell(command)
         {'shell' => command}
       end
-
-      # @!method copyartifact(options = {})
-      # Specify a `copyartifact` builder for a job. Requires the `copyartifact` plugin.
-      #
-      # See {https://docs.openstack.org/infra/jenkins-job-builder/builders.html#builders.copyartifact}.
-      #
-      # @param options [Hash] The configuration options for the component.
-      # @return [Hash] The specification for the component.
-      standard_component :copyartifact
     end
   end
 end

--- a/lib/jujube/components/builders.rb
+++ b/lib/jujube/components/builders.rb
@@ -3,6 +3,7 @@ module Jujube
 
     # Helper methods for creating builder components.
     module Builders
+      extend Macros
 
       # Specify a `shell` builder for a job.
       #
@@ -14,6 +15,14 @@ module Jujube
         {'shell' => command}
       end
 
+      # @!method copyartifact(options = {})
+      # Specify a `copyartifact` builder for a job. Requires the `copyartifact` plugin.
+      #
+      # See {https://docs.openstack.org/infra/jenkins-job-builder/builders.html#builders.copyartifact}.
+      #
+      # @param options [Hash] The configuration options for the component.
+      # @return [Hash] The specification for the component.
+      standard_component :copyartifact
     end
   end
 end

--- a/test/components/builders_test.rb
+++ b/test/components/builders_test.rb
@@ -3,11 +3,6 @@ require_relative "../test_helper"
 class BuildersTest < Minitest::Test
   include Jujube::Components
 
-  def test_shell
-    expected = {'shell' => 'COMMAND'}
-    assert_equal(expected, shell('COMMAND'))
-  end
-
   def test_copyartifact
     result = copyartifact(
       project: 'upstream-project',
@@ -24,5 +19,10 @@ class BuildersTest < Minitest::Test
       }
     }
     assert_equal(expected, result)
+  end
+
+  def test_shell
+    expected = {'shell' => 'COMMAND'}
+    assert_equal(expected, shell('COMMAND'))
   end
 end

--- a/test/components/builders_test.rb
+++ b/test/components/builders_test.rb
@@ -7,4 +7,22 @@ class BuildersTest < Minitest::Test
     expected = {'shell' => 'COMMAND'}
     assert_equal(expected, shell('COMMAND'))
   end
+
+  def test_copyartifact
+    result = copyartifact(
+      project: 'upstream-project',
+      which_build: 'last-successful',
+      target: 'dest_dir'
+      do_not_fingerprint: true
+    )
+    expected = {
+      'copyartifact' => {
+        'project' => 'upstream-project',
+        'which-build' => 'last-successful',
+        'target' => 'dest_dir',
+        'do-not-fingerprint' => true
+      }
+    }
+    assert_equal(expected, result)
+  end
 end

--- a/test/components/builders_test.rb
+++ b/test/components/builders_test.rb
@@ -12,7 +12,7 @@ class BuildersTest < Minitest::Test
     result = copyartifact(
       project: 'upstream-project',
       which_build: 'last-successful',
-      target: 'dest_dir'
+      target: 'dest_dir',
       do_not_fingerprint: true
     )
     expected = {


### PR DESCRIPTION
This is a simple `standard_component` for the Copy Artifact plugin.