### PR TITLE
Add concurrent to job definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+### Added
+
+* Support the `concurrent` job attribute
+(see https://docs.openstack.org/infra/jenkins-job-builder/definition.html?highlight=concurrent).
+
 ## [0.13.0][0.13.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![Maintenance Status](https://img.shields.io/badge/maintenance-active-green.svg)
 
 **Jujube** is a Ruby front-end for
-[jenkins-job-builder](https://github.com/openstack-infra/jenkins-job-builder).
+[jenkins-job-builder](https://opendev.org/jjb/jenkins-job-builder).
 
 jenkins-job-builder allows you to specify Jenkins jobs in YAML and then creates or
 updates the jobs in a running Jenkins instance.  It provides some tools for removing
@@ -101,6 +101,7 @@ The following job attributes are supported:
 * `block_upstream`
 * `block_downstream`
 * `quiet_period`
+* `concurrent`
 * `disabled`
 
 The following sections and components are supported:
@@ -116,7 +117,7 @@ The following sections and components are supported:
   `trigger`, `trigger_parameterized_builds`, `unittest`, `xunit`)
 * `notifications`: None defined yet
 
-See [the end-to-end example job](examples/fixtures/endToEnd/endToEnd.job) for example
+See [the end-to-end example job](acceptance/fixtures/endToEnd/endToEnd.job) for example
 uses of all of the supported attributes, sections, and components.
 
 In general, component options are typically specified as standard Ruby hashes.  The option

--- a/acceptance/fixtures/endToEnd/endToEnd.job
+++ b/acceptance/fixtures/endToEnd/endToEnd.job
@@ -4,6 +4,7 @@ job "endToEnd" do |j|
   j.block_upstream = true
   j.block_downstream = false
   j.quiet_period = 42
+  j.concurrent = true
   j.disabled = true
 
   j.axes << slave(:arch, %w{i386 amd64})

--- a/acceptance/fixtures/endToEnd/expected.yml
+++ b/acceptance/fixtures/endToEnd/expected.yml
@@ -6,6 +6,7 @@
     block-upstream: true
     block-downstream: false
     quiet-period: 42
+    concurrent: true
     disabled: true
     project-type: matrix
     axes:

--- a/lib/jujube/job.rb
+++ b/lib/jujube/job.rb
@@ -27,7 +27,7 @@ module Jujube
     # @!attribute name
     #   The name of the job - will be the name as seen in Jenkins.
     #
-    #   See {http://docs.openstack.org/infra/jenkins-job-builder/general.html}.
+    #   See {http://docs.openstack.org/infra/jenkins-job-builder/definition.html}.
     #
     #   @return [String]
     attribute :name
@@ -36,7 +36,7 @@ module Jujube
     #   The type of job. This normally does not need to be specified, as it
     #   will be inferred as `matrix` if any `axes` are added.
     #
-    #   See {http://docs.openstack.org/infra/jenkins-job-builder/general.html}.
+    #   See {http://docs.openstack.org/infra/jenkins-job-builder/definition.html}.
     #
     #   @return [String]
     attribute :project_type
@@ -44,7 +44,7 @@ module Jujube
     # @!attribute description
     #   The description of the job.
     #
-    #   See {http://docs.openstack.org/infra/jenkins-job-builder/general.html}.
+    #   See {http://docs.openstack.org/infra/jenkins-job-builder/definition.html}.
     #
     #   @return [String]
     attribute :description
@@ -52,7 +52,7 @@ module Jujube
     # @!attribute node
     #   The Jenkins node or named group where the job should be run.
     #
-    #   See {http://docs.openstack.org/infra/jenkins-job-builder/general.html}.
+    #   See {http://docs.openstack.org/infra/jenkins-job-builder/definition.html}.
     #
     #   @return [String]
     attribute :node
@@ -60,7 +60,7 @@ module Jujube
     # @!attribute block_upstream
     #   `true` if this job should block while upstream jobs are running.
     #
-    #   See {http://docs.openstack.org/infra/jenkins-job-builder/general.html}.
+    #   See {http://docs.openstack.org/infra/jenkins-job-builder/definition.html}.
     #
     #   @return [Boolean]
     attribute :block_upstream
@@ -68,7 +68,7 @@ module Jujube
     # @!attribute block_downstream
     #   `true` if this job should block while downstream jobs are running.
     #
-    #   See {http://docs.openstack.org/infra/jenkins-job-builder/general.html}.
+    #   See {http://docs.openstack.org/infra/jenkins-job-builder/definition.html}.
     #
     #   @return [Boolean]
     attribute :block_downstream
@@ -76,15 +76,23 @@ module Jujube
     # @!attribute quiet_period
     #   Number of seconds to wait between consecutive runs of the job.
     #
-    #   See {http://docs.openstack.org/infra/jenkins-job-builder/general.html}.
+    #   See {http://docs.openstack.org/infra/jenkins-job-builder/definition.html}.
     #
     #   @return [Fixnum]
     attribute :quiet_period
 
+    # @!attribute concurrent
+    #   `true` if this job should be concurrent.
+    #
+    #   See {https://docs.openstack.org/infra/jenkins-job-builder/definition.html?highlight=concurrent}.
+    #
+    #   @return [Boolean]
+    attribute :concurrent
+
     # @!attribute disabled
     #   `true` if this job should be disabled.
     #
-    #   See {http://docs.openstack.org/infra/jenkins-job-builder/general.html}.
+    #   See {http://docs.openstack.org/infra/jenkins-job-builder/definition.html}.
     #
     #   @return [Boolean]
     attribute :disabled

--- a/test/job_test.rb
+++ b/test/job_test.rb
@@ -40,6 +40,11 @@ class JobTest < Minitest::Test
     assert_yaml_matches("quiet-period: 42")
   end
 
+  def test_includes_concurrent
+    @job.concurrent = true
+    assert_yaml_matches("concurrent: true")
+  end
+
   def test_includes_disabled
     @job.disabled = true
     assert_yaml_matches("disabled: true")


### PR DESCRIPTION
I have added 'concurrent' to the job definition.
\+ updated the jenkins-job-builder links.

I'm not able to run `rake acceptance` since this test uses the `bin/jujube` and not the source code.
There was no documentation on how to build a new bin.
But I have adapted the `endToEnd` files.