### PR TITLE
Add the gtest type for xUnit test reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Support the `gtest` test result type in the `xunit` publisher.
+- Support the `gtest` test result type in the `xunit` publisher (see
+  https://jenkins-job-builder.readthedocs.io/en/latest/publishers.html#publishers.xunit)  ([#20](https://github.com/randycoulman/jujube/pull/20)) (with @robin-verhoeven)
 
 ## [0.15.0][0.15.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- Support the `gtest` test result type in the `xunit` publisher.
+
 ## [0.15.0][0.15.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The following sections and components are supported:
 * `wrappers`: (`timeout`, `timestamps`)
 * `builders`: (`copyartifact`, `shell`)
 * `publishers`: (`archive`, `cppcheck`, `email_ext`, `fitnesse`, `ircbot`, `junit`,
-  `trigger`, `trigger_parameterized_builds`, `unittest`, `xunit`)
+  `trigger`, `trigger_parameterized_builds`, `unittest`, `gtest`, `xunit`)
 * `notifications`: None defined yet
 
 See [the end-to-end example job](acceptance/fixtures/endToEnd/endToEnd.job) for example

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The following sections and components are supported:
 * `wrappers`: (`timeout`, `timestamps`)
 * `builders`: (`copyartifact`, `shell`)
 * `publishers`: (`archive`, `cppcheck`, `email_ext`, `fitnesse`, `ircbot`, `junit`,
-  `trigger`, `trigger_parameterized_builds`, `unittest`, `gtest`, `xunit`)
+  `trigger`, `trigger_parameterized_builds`, `xunit` (types `gtest` and `unittest`))
 * `notifications`: None defined yet
 
 See [the end-to-end example job](acceptance/fixtures/endToEnd/endToEnd.job) for example

--- a/acceptance/fixtures/endToEnd/endToEnd.job
+++ b/acceptance/fixtures/endToEnd/endToEnd.job
@@ -109,6 +109,7 @@ job "endToEnd" do |j|
                     git_revision: true)
   end
   j.publishers << xunit do |types|
-    types << unittest(pattern: "PATTERN", deleteoutput: false)
+    types << gtest(pattern: "GTEST_PATTERN", deleteoutput: false)
+    types << unittest(pattern: "UNITTEST_PATTERN", deleteoutput: false)
   end
 end

--- a/acceptance/fixtures/endToEnd/expected.yml
+++ b/acceptance/fixtures/endToEnd/expected.yml
@@ -176,6 +176,9 @@
             git-revision: true
       - xunit:
           types:
+            - gtest:
+                pattern: GTEST_PATTERN
+                deleteoutput: false
             - unittest:
-                pattern: PATTERN
+                pattern: UNITTEST_PATTERN
                 deleteoutput: false

--- a/lib/jujube/components/publishers.rb
+++ b/lib/jujube/components/publishers.rb
@@ -158,17 +158,6 @@ module Jujube
 
       # @!group xunit Test Types
 
-      # @!method unittest(options = {})
-      # Configure a `unittest` test type for an {#xunit} publisher.
-      #
-      # See {http://docs.openstack.org/infra/jenkins-job-builder/publishers.html#publishers.xunit}.
-      #
-      # @param options [Hash] The configuration options for the test type.
-      # @return [Hash] The specification for the test type.
-      named_config :unittest
-
-      # @!endgroup
-
       # @!method gtest(options = {})
       # Configure a `gtest` test type for an {#xunit} publisher.
       #
@@ -177,6 +166,15 @@ module Jujube
       # @param options [Hash] The configuration options for the test type.
       # @return [Hash] The specification for the test type.
       named_config :gtest
+
+      # @!method unittest(options = {})
+      # Configure a `unittest` test type for an {#xunit} publisher.
+      #
+      # See {http://docs.openstack.org/infra/jenkins-job-builder/publishers.html#publishers.xunit}.
+      #
+      # @param options [Hash] The configuration options for the test type.
+      # @return [Hash] The specification for the test type.
+      named_config :unittest
 
       # @!endgroup
     end

--- a/lib/jujube/components/publishers.rb
+++ b/lib/jujube/components/publishers.rb
@@ -168,6 +168,17 @@ module Jujube
       named_config :unittest
 
       # @!endgroup
+
+      # @!method gtest(options = {})
+      # Configure a `gtest` test type for an {#xunit} publisher.
+      #
+      # See {https://jenkins-job-builder.readthedocs.io/en/latest/publishers.html#publishers.xunit}.
+      #
+      # @param options [Hash] The configuration options for the test type.
+      # @return [Hash] The specification for the test type.
+      named_config :gtest
+
+      # @!endgroup
     end
   end
 end

--- a/test/components/publishers_test.rb
+++ b/test/components/publishers_test.rb
@@ -110,14 +110,14 @@ class PublishersTest < Minitest::Test
   def test_xunit
     expected = {"xunit" =>
                     {"types" => [
-                        {"unittest" => {"pattern" => "PATTERN", "deleteoutput" => false}},
-                        {"gtest" => {"pattern" => "PATTERN", "deleteoutput" => false}}
+                        {"gtest" => {"pattern" => "PATTERN", "deleteoutput" => false}},
+                        {"unittest" => {"pattern" => "PATTERN", "deleteoutput" => false}}
                       ]
                     }
     }
     actual = xunit do |types|
-      types << unittest(pattern: "PATTERN", deleteoutput: false)
       types << gtest(pattern: "PATTERN", deleteoutput: false)
+      types << unittest(pattern: "PATTERN", deleteoutput: false)
     end
     assert_equal(expected, actual)
   end

--- a/test/components/publishers_test.rb
+++ b/test/components/publishers_test.rb
@@ -109,12 +109,15 @@ class PublishersTest < Minitest::Test
 
   def test_xunit
     expected = {"xunit" =>
-                    {"types" =>
-                         [{"unittest" => {"pattern" => "PATTERN", "deleteoutput" => false}}]
+                    {"types" => [
+                        {"unittest" => {"pattern" => "PATTERN", "deleteoutput" => false}},
+                        {"gtest" => {"pattern" => "PATTERN", "deleteoutput" => false}}
+                      ]
                     }
     }
     actual = xunit do |types|
       types << unittest(pattern: "PATTERN", deleteoutput: false)
+      types << gtest(pattern: "PATTERN", deleteoutput: false)
     end
     assert_equal(expected, actual)
   end


### PR DESCRIPTION
Hello,

A new google test publisher type in the xunit test result publisher is needed as we converted a big part of our tests.

Thanks in advance for reviewing this.

With kind regards,

Robin